### PR TITLE
Change Device and User token urls

### DIFF
--- a/rmcl/const.py
+++ b/rmcl/const.py
@@ -3,8 +3,8 @@ import enum
 
 RFC3339Nano = "%Y-%m-%dT%H:%M:%SZ"
 USER_AGENT = "rmcl <https://github.com/rschroll/rmcl>"
-DEVICE_TOKEN_URL = "https://my.remarkable.com/token/json/2/device/new"
-USER_TOKEN_URL = "https://my.remarkable.com/token/json/2/user/new"
+DEVICE_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/device/new"
+USER_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/user/new"
 USER_TOKEN_VALIDITY = 24 * 60 * 60  # Guessing one day
 DEVICE_REGISTER_URL = "https://my.remarkable.com/connect/desktop"
 DEVICE = "desktop-windows"


### PR DESCRIPTION
The device and user token urls used by remarkable changed. See https://github.com/juruen/rmapi/pull/178 
I've also confirmed that these are the urls now used by the remarkable desktop app. Fixes #1 