### PR TITLE
allow setting mtime

### DIFF
--- a/rmcl/api.py
+++ b/rmcl/api.py
@@ -23,8 +23,7 @@ from .exceptions import (
     AuthError,
     DocumentNotFound,
     ApiError,)
-from .const import (RFC3339Nano,
-                    USER_AGENT,
+from .const import (USER_AGENT,
                     DEVICE_TOKEN_URL,
                     USER_TOKEN_URL,
                     USER_TOKEN_VALIDITY,
@@ -315,7 +314,6 @@ class Client:
         # Copy the metadata so that the object gets out of date and will be refreshed
         metadata = item._metadata.copy()
         metadata['Version'] += 1
-        metadata["ModifiedClient"] = now().strftime(RFC3339Nano)
         res = await self.request("PUT",
                                  "/document-storage/json/2/upload/update-status",
                                  body=[metadata])
@@ -341,6 +339,7 @@ class Client:
         if up_res.status_code >= 400:
             log.error(f"Upload failed with status {up_res.status_code}")
             raise ApiError(f"Upload failed with status {up_res.status_code}", response=up_res)
+        item.mtime = now()
         await self.update_metadata(item)
 
     @staticmethod

--- a/rmcl/items.py
+++ b/rmcl/items.py
@@ -15,7 +15,7 @@ except ImportError:
     render = None
 
 from . import api
-from .const import ROOT_ID, TRASH_ID, FileType
+from .const import ROOT_ID, TRASH_ID, FileType, RFC3339Nano
 from . import datacache
 from .exceptions import DocumentNotFound, VirtualItemError
 from .sync import add_sync
@@ -117,6 +117,10 @@ class Item:
     def mtime(self):
         return parse_datetime(self._metadata.get('ModifiedClient'))
 
+    @mtime.setter
+    def mtime(self, value):
+        self._metadata['ModifiedClient'] = value.strftime(RFC3339Nano)
+
     @property
     def virtual(self):
         return False
@@ -201,6 +205,7 @@ class Item:
             if folder.id == TRASH_ID:
                 return await client.delete(self)
         self.parent = TRASH_ID
+        self.mtime = now()
         await client.update_metadata(self)
 
     @add_sync


### PR DESCRIPTION
an attempt at resolving issue #5 

What I did was I moved the setting of the `ModifiedClient` metadata tag out of `api.update_metadata()` and instead set the `mtime` of items upon `Item.delete()` (not sure if required) and in `api.upload()`.

Tested with my own data, it works for me.