### PR TITLE
update device registration URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ program is run.  If rmcl detects that it is being run interactively, it
 will print instructions and prompt to user to input a new device token.
 Otherwise, it will throw a `rmcl.exceptions.AuthError`.  You must call
 `register_device(code)` with the code provided obtained from
-https://my.remarkable.com/connect/desktop.  Once obtained, the device
+https://my.remarkable.com/#desktop.  Once obtained, the device
 token is stored for future use.
 
 ## Comparison with rMapy

--- a/rmcl/api.py
+++ b/rmcl/api.py
@@ -130,12 +130,12 @@ class Client:
         """Registers a device on the Remarkable Cloud.
 
         This uses a unique code the user gets from
-        https://my.remarkable.com/connect/remarkable to register a new device
+        https://my.remarkable.com/#desktop to register a new device
         or client to be able to execute api calls.
 
         Args:
             code: A unique One time code the user can get
-                at https://my.remarkable.com/connect/remarkable .
+                at https://my.remarkable.com/#desktop .
         Returns:
             True
         Raises:

--- a/rmcl/const.py
+++ b/rmcl/const.py
@@ -6,7 +6,7 @@ USER_AGENT = "rmcl <https://github.com/rschroll/rmcl>"
 DEVICE_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/device/new"
 USER_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/user/new"
 USER_TOKEN_VALIDITY = 24 * 60 * 60  # Guessing one day
-DEVICE_REGISTER_URL = "https://my.remarkable.com/connect/desktop"
+DEVICE_REGISTER_URL = "https://my.remarkable.com/#desktop"
 DEVICE = "desktop-windows"
 SERVICE_MGR_URL = "https://service-manager-production-dot-remarkable-production.appspot.com/service/json/1/document-storage?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=2"  # noqa
 # Number of bytes of file to request to get file size of source doc


### PR DESCRIPTION
The device registration page doesn't work, so I've updated every mention of the old URL to the new one. Codes generated from the new URL seem to work fine with the rest of the code, but I did not extensively test.

This should close issue https://github.com/rschroll/rmcl/issues/7