### PR TITLE
enabled capability to interact with rmfakecloud cloud servers

### DIFF
--- a/rmcl/const.py
+++ b/rmcl/const.py
@@ -2,13 +2,19 @@ import datetime
 import enum
 
 RFC3339Nano = "%Y-%m-%dT%H:%M:%SZ"
+
+DEFAULT_TOKEN_SERVER_URL = "https://webapp-production-dot-remarkable-production.appspot.com"
+DEFAULT_SERVICE_MGR_SERVER_URL = "https://service-manager-production-dot-remarkable-production.appspot.com"
+DEVICE_REGISTER_URL = "https://my.remarkable.com/device/desktop/connect"
+
 USER_AGENT = "rmcl <https://github.com/rschroll/rmcl>"
-DEVICE_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/device/new"
-USER_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/user/new"
+
+DEVICE_TOKEN_PATH = "/token/json/2/device/new"
+USER_TOKEN_PATH = "/token/json/2/user/new"
+SERVICE_MGR_PATH = "/service/json/1/document-storage?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=2"  # noqa
+
 USER_TOKEN_VALIDITY = 24 * 60 * 60  # Guessing one day
-DEVICE_REGISTER_URL = "https://my.remarkable.com/connect/desktop"
 DEVICE = "desktop-windows"
-SERVICE_MGR_URL = "https://service-manager-production-dot-remarkable-production.appspot.com/service/json/1/document-storage?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=2"  # noqa
 # Number of bytes of file to request to get file size of source doc
 # For notes, the central directory runs 5 pages / KB, as a rough guess
 NBYTES = 1024*100


### PR DESCRIPTION
This PR adds the capability to check for other (well-configured) cloud servers.

One the first run the user is prompted for the server URL. Default is the official remarkable cloud.
Once that has been set everything continues as usual, the user must provide a one-time-code, etc.

From a technical perspective a few things have changed: all the constants in `const.py` like `DEVICE_TOKEN_URL` were split up into `DEFAULT_TOKEN_SERVER_URL` and `DEVICE_TOKEN_PATH`.

The `api.py` now uses `self.config['device_token_url']` instead of `DEVICE_TOKEN_URL`. The value of these values is calculated after the initial prompt for the server url and saved in the config file (e.g. `$HOME/.config/rmcl/config.json`).

Analogously `USER_TOKEN_URL` and `SERVICE_MGR_URL` where split up, calculated and put into the config dict.

It might not be the most elegant solution, but it works for me (tested with `rmfakecloud` and the official cloud)